### PR TITLE
Add kopano konnect and a caddy as proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+.caddy

--- a/kopano/konnect/Caddyfile
+++ b/kopano/konnect/Caddyfile
@@ -1,0 +1,38 @@
+{$KOPANO_KONNECT_DOMAIN}:80, {$KOPANO_KONNECT_DOMAIN}:443 {
+	errors stderr
+	log stdout
+
+	tls self_signed
+
+	# konnect oidc
+	proxy /.well-known/openid-configuration kopano_konnect:8777
+	proxy /konnect/v1/jwks.json kopano_konnect:8777
+	proxy /konnect/v1/token kopano_konnect:8777
+	proxy /konnect/v1/userinfo kopano_konnect:8777
+	proxy /konnect/v1/static kopano_konnect:8777
+	proxy /konnect/v1/session kopano_konnect:8777
+	proxy /konnect/v1/register kopano_konnect:8777
+
+	# konnect identifier login area
+	proxy /signin/ kopano_konnect:8777 {
+		transparent
+	}
+
+	# owncloud 10
+	proxy /oc10 owncloud:8080 {
+#		without /oc10
+		transparent
+	}
+}
+
+{$OWNCLOUD_DOMAIN}:80, {$OWNCLOUD_DOMAIN}:443 {
+	errors stderr
+	log stdout
+
+	tls self_signed
+
+	# owncloud 10
+	proxy / owncloud:8080 {
+		transparent
+	}
+}

--- a/kopano/konnect/README.md
+++ b/kopano/konnect/README.md
@@ -1,0 +1,28 @@
+Setup the domain name in /etc/hosts - assuming you are on linux
+
+127.0.0.1 konnect.docker-playground.local
+127.0.0.1 owncloud.docker-playground.local
+
+```console
+KOPANO_KONNECT_DOMAIN=konnect.docker-playground.local
+OWNCLOUD_DOMAIN=owncloud.docker-playground.local
+docker-compose \
+    -f owncloud-base.yml \
+    -f owncloud-official.yml \
+    -f cache/redis.yml \
+    -f database/mariadb.yml \
+    -f ldap/openldap.yml \
+    -f ldap/openldap-mount-ldif.yml \
+    -f ldap/openldap-autoconfig-base.yml \
+    -f kopano/konnect/docker-compose.yml \
+    up
+```
+
+Go to owncloud: https://owncloud.docker-playground.local
+Click the alternative login button 'Kopano'
+
+On the login of kopano konnect use aaliyah_abernathy / secret to login
+
+This is the well-known address to be used for OpenID Connect
+https://konnect.docker-playground.local/.well-known/openid-configuration
+

--- a/kopano/konnect/docker-compose.yml
+++ b/kopano/konnect/docker-compose.yml
@@ -1,0 +1,87 @@
+version: '3.4'
+
+services:
+  kopano_ssl:
+    image: ${docker_repo:-zokradonh}/kopano_ssl:${SSL_VERSION:-latest}
+    read_only: true
+    environment:
+      - FQDN=${KOPANO_KONNECT_DOMAIN}
+      - PKI_COUNTRY=NL
+    volumes:
+      - kopanossl/:/kopano/ssl
+    tmpfs:
+      - /kopano/easypki/
+
+  kopano_konnect:
+    image: kopano/kopano_konnect:${KONNECT_VERSION:-latest}
+    ports:
+      - 8777:8777
+    read_only: true
+    restart: unless-stopped
+    depends_on:
+      - openldap
+      - kopano_ssl
+    volumes:
+      - /etc/machine-id:/etc/machine-id
+      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id
+      - ./kopano/konnect/konnectd-identifier-registration.yaml:/etc/kopano/konnectd-identifier-registration.yaml
+      - kopanosocket/:/run/kopano
+      - kopanossl/:/kopano/ssl
+    environment:
+      - allow_client_guests=yes
+      - allow_dynamic_client_registration=yes
+      - eckey=/kopano/ssl/meet-kwmserver.pem
+      - ecparam=/kopano/ssl/ecparam.pem
+      - encryption_secret_key=/kopano/ssl/konnectd-encryption.key
+      - FQDN=${KOPANO_KONNECT_DOMAIN}
+      - identifier_registration_conf=/kopano/ssl/konnectd-identifier-registration.yaml
+      - identifier_scopes_conf=/etc/kopano/konnectd-identifier-scopes.yaml
+      - signing_private_key=/kopano/ssl/konnectd-tokens-signing-key.pem
+      - validation_keys_path=/kopano/ssl/konnectkeys
+      - KONNECT_BACKEND=ldap
+      - LDAP_BASEDN=dc=owncloudqa,dc=com
+      - LDAP_BINDDN=cn=admin,dc=owncloudqa,dc=com
+      - LDAP_BINDPW=owncloud123
+      - LDAP_EMAIL_ATTRIBUTE=mail
+      - LDAP_FILTER=(objectClass=organizationalPerson)
+      - LDAP_LOGIN_ATTRIBUTE=uid
+      - LDAP_NAME_ATTRIBUTE=cn
+      - LDAP_SCOPE=sub
+      - LDAP_URI=ldap://openldap:389
+      - LDAP_UUID_ATTRIBUTE_TYPE=text
+      - LDAP_UUID_ATTRIBUTE=uidNumber
+    tmpfs:
+      - /tmp
+
+  caddy:
+    image: "abiosoft/caddy:latest"
+    volumes:
+      - ./.caddy:/root/.caddy # to sync mkcert certificates to Caddy
+      - ./kopano/konnect/Caddyfile:/etc/Caddyfile  # to mount custom Caddyfile
+    ports:
+      - 80:80
+      - 443:443
+      - 2015:2015
+    environment:
+      - ACME_AGREE=true
+      - KOPANO_KONNECT_DOMAIN=${KOPANO_KONNECT_DOMAIN}
+    networks: 
+      default:
+        aliases: 
+          - ${KOPANO_KONNECT_DOMAIN}  
+          - ${OWNCLOUD_DOMAIN}  
+  
+  owncloud:
+    volumes: 
+      - ./kopano/konnect/openid.sh:/etc/pre_server.d/10-openid.sh
+    environment:
+      - KOPANO_KONNECT_DOMAIN=${KOPANO_KONNECT_DOMAIN}
+      - OWNCLOUD_DOMAIN=${OWNCLOUD_DOMAIN}
+      - OWNCLOUD_APPS_INSTALL=https://github.com/owncloud/openidconnect/releases/download/v0.2.0/openidconnect-0.2.0.tar.gz
+      - OWNCLOUD_APPS_ENABLE="openidconnect"
+      - OWNCLOUD_LOGLEVEL=0
+      
+volumes:
+    kopanosocket:
+    kopanossl:
+      

--- a/kopano/konnect/konnectd-identifier-registration.yaml
+++ b/kopano/konnect/konnectd-identifier-registration.yaml
@@ -1,0 +1,31 @@
+---
+# OpenID Connect client registry.
+clients:
+  - id: ownCloud 
+    secret: ownCloud
+    application_type: web
+    insecure: true
+
+  - id: xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69
+    secret: UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh
+    application_type: native
+    insecure: true
+
+  - id: e4rAsNUSIUs0lF4nbv9FmCeUkTlV9GdgTLDH1b5uie7syb90SzEVrbN7HIpmWJeD
+    secret: dInFYGV33xKzhbRmpqQltYNdfLdJIfJ9L5ISoKhNoT9qZftpdWSP71VrpGR9pmoD
+    application_type: native
+    redirect_uris:
+      - oc://android.owncloud.com
+
+  - id: mxd5OQDk6es5LzOzRvidJNfXLUZS2oN3oUFeXPP8LpPrhx3UroJFduGEYIBOxkY1
+    secret: KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx
+    application_type: native
+    redirect_uris:
+      - oc://ios.owncloud.com
+      - oc.ios://ios.owncloud.com
+
+  - id: phoenix
+    application_type: web
+    trusted: true
+    redirect_uris:
+      - https://oidc-workshop.owncloud-demo.com/oidc-callback.html

--- a/kopano/konnect/openid.sh
+++ b/kopano/konnect/openid.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -x
+
+CONFIG=$(cat <<EOF
+{
+    "system": {
+        "openid-connect": {
+       		"provider-url": "https://$KOPANO_KONNECT_DOMAIN",
+            "client-id": "ownCloud",
+            "client-secret": "ownCloud",
+            "loginButtonName": "Kopano",
+            "autoRedirectOnLoginPage": false,
+            "redirect-url": "https://$OWNCLOUD_DOMAIN/index.php/apps/openidconnect/redirect",
+            "mode": "userid",
+            "search-attribute": "preferred_username",
+            "use-token-introspection-endpoint": false
+        },
+        "debug": true
+    }
+}
+EOF
+)
+
+occ config:import <<< $CONFIG
+occ app:enable user_ldap
+occ ldap:test-config "s01"
+
+true

--- a/ldap/ldap.sh
+++ b/ldap/ldap.sh
@@ -23,7 +23,7 @@ CONFIG=$(cat <<EOF
             "s01ldap_dynamic_group_member_url": "",
             "s01ldap_email_attr": "",
             "s01ldap_experienced_admin": "0",
-            "s01ldap_expert_username_attr": "",
+            "s01ldap_expert_username_attr": "uid",
             "s01ldap_expert_uuid_group_attr": "",
             "s01ldap_expert_uuid_user_attr": "",
             "s01ldap_group_display_name": "cn",
@@ -51,7 +51,7 @@ CONFIG=$(cat <<EOF
             "s01ldap_userfilter_groups": "",
             "s01ldap_userfilter_objectclass": "",
             "s01ldap_userlist_filter": "(objectclass=*)",
-            "s01use_memberof_to_detect_membership": "1"
+            "s01use_memberof_to_detect_membership": "1",
         }
     }
 }


### PR DESCRIPTION
Setup the domain name in etch/hosts - assuming you are on linux

127.0.0.1 konnect.docker-playground.local
127.0.0.1 owncloud.docker-playground.local

```
KOPANO_KONNECT_DOMAIN=konnect.docker-playground.local
OWNCLOUD_DOMAIN=owncloud.docker-playground.local
docker-compose \
    -f owncloud-base.yml \
    -f owncloud-official.yml \
    -f cache/redis.yml \
    -f database/mariadb.yml \
    -f ldap/openldap.yml \
    -f ldap/openldap-mount-ldif.yml \
    -f ldap/openldap-autoconfig-base.yml \
    -f kopano/konnect/docker-compose.yml \
    up
```


https://konnect.docker-playground.local/.well-known/openid-configuration

web login: https://konnect.docker-playground.local/signin/v1/identifier
aaliyah_abernathy / secret

owncloud: https://owncloud.docker-playground.local