### PR TITLE
Add ocis to compose playground

### DIFF
--- a/cache/redis-ocis.yml
+++ b/cache/redis-ocis.yml
@@ -1,0 +1,15 @@
+version: '3.4'
+
+services:
+  ocis:
+    depends_on:
+      - redis
+    environment:
+      - REVA_STORAGE_OWNCLOUD_REDIS_ADDR=redis:6379
+
+
+  redis:
+    image: redis
+    restart: always
+    environment:
+      - REDIS_MAXCONN=10000

--- a/ocis/README.md
+++ b/ocis/README.md
@@ -1,0 +1,15 @@
+# compose-playground for ocis
+
+This repository provides different docker-compose yaml files acting as various "infrastructure components".
+
+The aim of these components is, to provide an easy way of setting up owncloud with different infrastrucutre scenarions.
+
+For example, we want to run a *ocis* combined with *redis*.
+This could be done by using the following `docker-compose` statement:
+
+```bash
+docker-compose \
+    -f ocis.yml \
+    -f ../cache/redis-ocis.yml \
+    up
+```

--- a/ocis/ocis.yml
+++ b/ocis/ocis.yml
@@ -1,0 +1,18 @@
+---
+version: '3.4'
+
+services:
+  ocis:
+    restart: always
+    image: owncloud/ocis:${OCIS_DOCKER_TAG:-1.0.0-beta1}
+    ports:
+        - ${OCIS_HTTP_PORT:-9200}:9200
+    volumes:
+        - ${OCIS_OWNCLOUD_DATADIR:-/tmp/}:/var/tmp/reva/data
+    environment:
+        - KONNECTD_ISS
+        - REVA_OIDC_ISSUER
+        - PHOENIX_OIDC_AUTHORITY
+        - PHOENIX_WEB_CONFIG_SERVER
+        - PHOENIX_OIDC_METADATA_URL
+        - PHOENIX_ASSET_PATH


### PR DESCRIPTION
# compose-playground for ocis

This repository provides different docker-compose yaml files acting as various "infrastructure components".

The aim of these components is, to provide an easy way of setting up owncloud with different infrastrucutre scenarions.

For example, we want to run a *ocis* combined with *redis*.
This could be done by using the following `docker-compose` statement:

```bash
docker-compose \
    -f ocis.yml \
    -f ../cache/redis-ocis.yml \
    up
```