### PR TITLE
Add defaults to swith the base url

### DIFF
--- a/ocis/config/identifier-registration.yml
+++ b/ocis/config/identifier-registration.yml
@@ -1,0 +1,31 @@
+---
+    # OpenID Connect client registry.
+    clients:
+      - id: phoenix
+        name: OCIS
+        application_type: web
+        insecure: yes
+        redirect_uris:
+          - http://localhost:9100/oidc-callback.html
+          - http://localhost:9100
+          - https://localhost:9200
+          - https://localhost:9200/oidc-callback.html
+          - https://your-url:9200
+          - https://your-url:9200/oidc-callback.html
+        origins:
+          - http://localhost:9100
+          - https://localhost:9200
+          - https://your-url:9200
+    
+      - id: owncloud10
+        name: OC10
+        application_type: web
+        insecure: yes
+        redirect_uris:
+          - http://localhost:9100/oidc-callback.html
+          - http://localhost:9100
+          - https://localhost:9200
+          - https://localhost:9200/oidc-callback.html
+        origins:
+          - http://localhost:9100
+          - https://localhost:9200

--- a/ocis/ocis.yml
+++ b/ocis/ocis.yml
@@ -4,15 +4,20 @@ version: '3.4'
 services:
   ocis:
     restart: always
-    image: owncloud/ocis:${OCIS_DOCKER_TAG:-1.0.0-beta1}
+    image: owncloud/ocis:${OCIS_DOCKER_TAG:-latest}
     ports:
         - ${OCIS_HTTP_PORT:-9200}:9200
     volumes:
         - ${OCIS_OWNCLOUD_DATADIR:-/tmp/}:/var/tmp/reva/data
+        - ${PWD}/config:/etc/ocis/:rw
     environment:
-        - KONNECTD_ISS
-        - REVA_OIDC_ISSUER
-        - PHOENIX_OIDC_AUTHORITY
-        - PHOENIX_WEB_CONFIG_SERVER
-        - PHOENIX_OIDC_METADATA_URL
-        - PHOENIX_ASSET_PATH
+        - PROXY_HTTP_ADDR=0.0.0.0:9200
+        - KONNECTD_ISS=https://${OCIS_BASE_URL:-localhost}:9200
+        - REVA_OIDC_ISSUER=https://${OCIS_BASE_URL:-localhost}:9200
+        - PHOENIX_OIDC_AUTHORITY=https://${OCIS_BASE_URL:-localhost}:9200
+        - PHOENIX_WEB_CONFIG_SERVER=https://${OCIS_BASE_URL:-localhost}:9200
+        - PHOENIX_OIDC_METADATA_URL=https://${OCIS_BASE_URL:-localhost}:9200/.well-known/openid-configuration
+        - KONNECTD_TLS=0
+        - OCIS_LOG_LEVEL=debug
+        - KONNECTD_LOG_LEVEL=debug
+        - KONNECTD_IDENTIFIER_REGISTRATION_CONF=/etc/ocis/identifier-registration.yml


### PR DESCRIPTION
## Make base url configurable in docker-compose

1) Edit the file `config/identifier-registration.yml`. Add your target URL to `redirect_uris` and `origins`
```
redirect_uris:
          - http://localhost:9100/oidc-callback.html
          - http://localhost:9100
          - https://localhost:9200
          - https://localhost:9200/oidc-callback.html
          - https://your-url:9200
          - https://your-url:9200/oidc-callback.html
        origins:
          - http://localhost:9100
          - https://localhost:9200
          - https://your-url:9200
```
2) Create an `.env` file in the `ocis` directory

```
OCIS_BASE_URL=your-url
OCIS_HTTP_PORT=9200
OCIS_DOCKER_TAG=latest
```

3) `docker-compose -f ocis.yml -f ../cache/redis-ocis.yml up`