### PR TITLE
Add default client ID's to ocis/config/identifier-registration.yml

### DIFF
--- a/ocis/config/identifier-registration.yml
+++ b/ocis/config/identifier-registration.yml
@@ -16,7 +16,7 @@
           - http://localhost:9100
           - https://localhost:9200
           - https://your-url:9200
-    
+
       - id: owncloud10
         name: OC10
         application_type: web
@@ -29,3 +29,21 @@
         origins:
           - http://localhost:9100
           - https://localhost:9200
+
+      - id: xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69
+        secret: UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh
+        application_type: native
+        insecure: true
+
+      - id: e4rAsNUSIUs0lF4nbv9FmCeUkTlV9GdgTLDH1b5uie7syb90SzEVrbN7HIpmWJeD
+        secret: dInFYGV33xKzhbRmpqQltYNdfLdJIfJ9L5ISoKhNoT9qZftpdWSP71VrpGR9pmoD
+        application_type: native
+        redirect_uris:
+          - oc://android.owncloud.com
+
+      - id: mxd5OQDk6es5LzOzRvidJNfXLUZS2oN3oUFeXPP8LpPrhx3UroJFduGEYIBOxkY1
+        secret: KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx
+        application_type: native
+        redirect_uris:
+          - oc://ios.owncloud.com
+          - oc.ios://ios.owncloud.com


### PR DESCRIPTION
Fixes https://github.com/owncloud-docker/compose-playground/issues/10

```
git clone https://github.com/owncloud-docker/compose-playground.git

cd compose-playground/ocis

sed -i -e 's/your-url/192.168.103.195/g' config/identifier-registration.yml

cat << EOF > .env
OCIS_BASE_URL=192.168.103.195
OCIS_HTTP_PORT=9200
OCIS_DOCKER_TAG=latest
EOF

docker-compose -f ocis.yml -f ../cache/redis-ocis.yml up -d

curl -k https://192.168.103.195:9200/status.php
```