### PR TITLE
don't use symlinks for volume mounts

### DIFF
--- a/kopano/konnect/docker-compose.yml
+++ b/kopano/konnect/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - kopano_ssl
     volumes:
       - /etc/machine-id:/etc/machine-id
-      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id
+      - /etc/machine-id:/var/lib/dbus/machine-id
       - ./kopano/konnect/konnectd-identifier-registration.yaml:/etc/kopano/konnectd-identifier-registration.yaml
       - kopanosocket/:/run/kopano
       - kopanossl/:/kopano/ssl


### PR DESCRIPTION
This seems docker runtime dependant. 
On some systems a symlink on the host `/var/lib/dbus/machine-id -> /etc/machine-id` can be used, on some not.
Fix: Always use the link destination.