### PR TITLE
Expose data storage port 9160

### DIFF
--- a/examples/eos-compose/docker-compose.yml
+++ b/examples/eos-compose/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     stdin_open: true
     ports: 
       - 9200:9200
+      - 9160:9160
     env_file:
       - ./config/eos-docker.env
     hostname: ocis


### PR DESCRIPTION
Required for TUS uploads that talk directly to the data provider