### PR TITLE
Make upload work

### DIFF
--- a/examples/eos-compose/docker-compose.yml
+++ b/examples/eos-compose/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     tty: true
     privileged: true
     stdin_open: true
-    ports: 
+    ports:
       - 9200:9200
       - 9160:9160
     env_file:
@@ -22,7 +22,7 @@ services:
       - testnet
     volumes:
       - ./config:/config
-    environment: 
+    environment:
       EOS_MGM_URL: "root://mgm-master.testnet:1094"
       OCIS_DOMAIN: ${OCIS_DOMAIN}
       KONNECTD_IDENTIFIER_REGISTRATION_CONF: /etc/ocis/identifier-registration.yml
@@ -80,7 +80,7 @@ services:
     - ./e/master/var/eos/ns-queue:/var/eos/ns-queue
     environment:
       EOS_SET_MASTER: 1
-    
+
   fst:
     container_name: fst
     image: eos/fst
@@ -97,6 +97,7 @@ services:
     - ./e/disks:/disks
     environment:
       EOS_MGM_URL: "root://mgm-master.testnet"
+      LUKSPASSPHRASE: "just-some-rubbish-to-make-sure-fst-entrypoint-does-not-crash"
 
   quark-1:
     container_name: quark-1

--- a/examples/eos-compose/eos-fst/setup
+++ b/examples/eos-compose/eos-fst/setup
@@ -7,4 +7,5 @@ for i in {1..4}; do
   mkdir -p /disks/eosfs${i}
   chown daemon:daemon /disks/eosfs${i}
   eos -r 0 0 -b fs add eosfs${i} fst.testnet:1095 /disks/eosfs${i} default rw
+  eos -r 0 0 space set default on
 done


### PR DESCRIPTION
1. fst used to stop the staetup process with: 
    ```
    fst           | Setting /tmp to mode 1777
    fst           | Unmounting any existing mounts for file systems
    fst           | ls: cannot access /hostdev/mapper/: No such file or directory
    fst           | ls: cannot access /dev/mapper/luks*: No such file or directory
    fst           | ls: cannot access /dev/mapper/*: No such file or directory
    fst           | trying to unlock luks encrypted disk with no passphrase, what are you doing
    ```
    so set some passphrase so that the script runs, even it does not decrypt anything

2. the default space was created but not enabled. see http://eos-docs.web.cern.ch/eos-docs/quickstart/admin/configure.html#configure-mgm

test: 
```
$ ME=artur-neumann
$ SERVER_NAME=$ME-upload-test
$ hcloud server create --type cx21 --image ubuntu-20.04 --ssh-key $ME --name $SERVER_NAME --label owner=$ME --label for=test --label from=eos-compose
$ IPADDR=$(hcloud server ip $SERVER_NAME)
$ ssh -t root@$IPADDR apt-get update -y
$ ssh -t root@$IPADDR apt-get install -y git screen docker.io docker-compose
$ ssh -t root@$IPADDR git clone https://github.com/owncloud-docker/compose-playground.git
$ ssh -t root@$IPADDR "cd compose-playground/examples/eos-compose && git checkout make-upload-work && ./build"
$ ssh -t root@$IPADDR "cd compose-playground/examples/eos-compose && echo OCIS_DOMAIN=$IPADDR > .env && docker-compose up -d"
$ curl -k -u einstein:relativity -X PUT https://$IPADDR:9200/remote.php/dav/files/e/einstein/file.txt -d "123" -v
$ curl -k -u einstein:relativity -X PROPFIND https://$IPADDR:9200/remote.php/dav/files/e/einstein | xmllint --format -
$ curl -k -u einstein:relativity  https://$IPADDR:9200/remote.php/dav/files/e/einstein/file.txt