### PR TITLE
identifier-registration.yml of benchmark composer is generated by bash script with respect to the ${OCIS_DOMAIN} environment variable

### DIFF
--- a/examples/benchmark/ocis/Makefile
+++ b/examples/benchmark/ocis/Makefile
@@ -1,0 +1,7 @@
+docker-compose-up:
+	bash create-identifier-registration.sh
+	docker-compose up
+
+docker-compose-down:
+	rm -f config/identifier-registration.yml
+	docker-compose down -v

--- a/examples/benchmark/ocis/Makefile
+++ b/examples/benchmark/ocis/Makefile
@@ -1,5 +1,9 @@
 docker-compose-up:
 	bash create-identifier-registration.sh
+	docker-compose up -d
+
+docker-compose-up-foreground:
+	bash create-identifier-registration.sh
 	docker-compose up
 
 docker-compose-down:

--- a/examples/benchmark/ocis/create-identifier-registration.sh
+++ b/examples/benchmark/ocis/create-identifier-registration.sh
@@ -1,4 +1,5 @@
----
+#!/bin/bash
+echo "---
 
 # OpenID Connect client registry.
 clients:
@@ -13,4 +14,4 @@ clients:
     origins:
       -  https://${OCIS_DOMAIN}:9200
 
-authorities:
+authorities:" > $PWD/config/identifier-registration.yml


### PR DESCRIPTION
### Description
- A bash file is created which dynamically creates an `identifier-registration.yml` file by reading the environment variable `OCIS_DOMAIN`.
- Makefile is made to run docker-compose commands

### Docker compose commands
- `make docker-compose-up` 
- `make docker-compose-down`

### Related issues
closes https://github.com/owncloud-docker/compose-playground/issues/46