### PR TITLE
Fixes for kopano setup

### DIFF
--- a/compose/kopano/konnect/Caddyfile
+++ b/compose/kopano/konnect/Caddyfile
@@ -2,7 +2,7 @@
 	errors stderr
 	log stdout
 
-	tls self_signed
+	tls internal
 
 	# konnect oidc
 	proxy /.well-known/openid-configuration kopano_konnect:8777
@@ -29,7 +29,7 @@
 	errors stderr
 	log stdout
 
-	tls self_signed
+	tls internal
 
 	# owncloud 10
 	proxy / owncloud:8080 {

--- a/compose/kopano/konnect/Caddyfile
+++ b/compose/kopano/konnect/Caddyfile
@@ -2,6 +2,7 @@
 	errors stderr
 	log stdout
 
+	# https://caddyserver.com/docs/caddyfile/directives/tls
 	tls internal
 
 	# konnect oidc

--- a/compose/kopano/konnect/Caddyfile
+++ b/compose/kopano/konnect/Caddyfile
@@ -36,6 +36,7 @@
 	tls self_signed
 
 	# owncloud 10
+	proxy /.well-known/openid-configuration kopano_konnect:8777
 	proxy / owncloud:8080 {
 		transparent
 	}

--- a/compose/kopano/konnect/Caddyfile
+++ b/compose/kopano/konnect/Caddyfile
@@ -36,6 +36,8 @@
 	tls self_signed
 
 	# owncloud 10
+        ## FIXME: the static .well-known is bad. It should (as seen in Caddyfile.v2) go through
+	# rewrite /.well-known/openid-configuration /index.php/apps/openidconnect/config
 	proxy /.well-known/openid-configuration kopano_konnect:8777
 	proxy / owncloud:8080 {
 		transparent

--- a/compose/kopano/konnect/Caddyfile
+++ b/compose/kopano/konnect/Caddyfile
@@ -3,7 +3,10 @@
 	log stdout
 
 	# https://caddyserver.com/docs/caddyfile/directives/tls
-	tls internal
+	# abiosoft/caddy:latest caddy_version 1.0.3 interprets 'tls internal' as an email-address and fails.
+	# v1: 'tsl self_signed' generate and use an untrusted, self-signed certificate in memory that lasts 7 days
+	# caddy/latest CADDY_VERSION: 2.1.1 understands tls internal.
+	tls self_signed
 
 	# konnect oidc
 	proxy /.well-known/openid-configuration kopano_konnect:8777
@@ -30,7 +33,7 @@
 	errors stderr
 	log stdout
 
-	tls internal
+	tls self_signed
 
 	# owncloud 10
 	proxy / owncloud:8080 {

--- a/compose/kopano/konnect/Caddyfile.v2
+++ b/compose/kopano/konnect/Caddyfile.v2
@@ -8,7 +8,7 @@
 	#	tls internal
 
 	# konnect oidc
-	everse_proxy /.well-known/* kopano_konnect:8777
+	reverse_proxy /.well-known/* kopano_konnect:8777
 	reverse_proxy /konnect/* kopano_konnect:8777
 	
 	# konnect identifier login area

--- a/compose/kopano/konnect/Caddyfile.v2
+++ b/compose/kopano/konnect/Caddyfile.v2
@@ -1,0 +1,76 @@
+{$KOPANO_KONNECT_DOMAIN}:80 {
+	# errors stderr
+	log
+
+	# konnect oidc
+	reverse_proxy /.well-known/openid-configuration kopano_konnect:8777
+	reverse_proxy /konnect/v1/jwks.json kopano_konnect:8777
+	reverse_proxy /konnect/v1/token kopano_konnect:8777
+	reverse_proxy /konnect/v1/userinfo kopano_konnect:8777
+	reverse_proxy /konnect/v1/static kopano_konnect:8777
+	reverse_proxy /konnect/v1/session kopano_konnect:8777
+	reverse_proxy /konnect/v1/register kopano_konnect:8777
+
+	# konnect identifier login area
+	reverse_proxy /signin/ kopano_konnect:8777 {
+#		transparent
+	}
+
+	# owncloud 10
+	reverse_proxy /oc10 owncloud:8080 {
+#		without /oc10
+#		transparent
+	}
+}
+
+{$KOPANO_KONNECT_DOMAIN}:443 {
+	# errors stderr
+	log
+
+	# https://caddyserver.com/docs/caddyfile/directives/tls
+	# abiosoft/caddy:latest caddy_version 1.0.3 interprets 'tls internal' as an email-address and fails.
+	# caddy/latest CADDY_VERSION: 2.1.1 understands tls internal.
+	tls internal
+
+	# konnect oidc
+	reverse_proxy /.well-known/openid-configuration kopano_konnect:8777
+	reverse_proxy /konnect/v1/jwks.json kopano_konnect:8777
+	reverse_proxy /konnect/v1/token kopano_konnect:8777
+	reverse_proxy /konnect/v1/userinfo kopano_konnect:8777
+	reverse_proxy /konnect/v1/static kopano_konnect:8777
+	reverse_proxy /konnect/v1/session kopano_konnect:8777
+	reverse_proxy /konnect/v1/register kopano_konnect:8777
+
+	# konnect identifier login area
+	reverse_proxy /signin/ kopano_konnect:8777 {
+#		transparent
+	}
+
+	# owncloud 10
+	reverse_proxy /oc10 owncloud:8080 {
+#		without /oc10
+#		transparent
+	}
+}
+
+{$OWNCLOUD_DOMAIN}:80 {
+	# errors stderr
+	log
+
+	# owncloud 10
+	reverse_proxy / owncloud:8080 {
+#		transparent
+	}
+}
+
+{$OWNCLOUD_DOMAIN}:443 {
+	# errors stderr
+	log
+
+	tls internal
+
+	# owncloud 10
+	reverse_proxy / owncloud:8080 {
+#		transparent
+	}
+}

--- a/compose/kopano/konnect/Caddyfile.v2
+++ b/compose/kopano/konnect/Caddyfile.v2
@@ -32,8 +32,7 @@
 	## simple static well known, directly to the idp:
 	# reverse_proxy /.well-known/* kopano_konnect:8777
 	## better let the well-known url be handled by the openidconnect app:
-	redir /.well-known/openid-configuration /index.php/apps/openidconnect/config 301
-	## best, do so with an internal redirect, so that it is invisible to the web clients.
+	## Do so with an internal redirect, as the well known urls must not be redirected with HTTP/30x
 	rewrite /.well-known/openid-configuration /index.php/apps/openidconnect/config
 	## avoid a security warning:
 	header Strict-Transport-Security max-age=15552000;

--- a/compose/kopano/konnect/Caddyfile.v2
+++ b/compose/kopano/konnect/Caddyfile.v2
@@ -10,7 +10,7 @@
 	# konnect oidc
 	reverse_proxy /.well-known/* kopano_konnect:8777
 	reverse_proxy /konnect/* kopano_konnect:8777
-	
+
 	# konnect identifier login area
 	reverse_proxy /signin/* kopano_konnect:8777 {
 	}

--- a/compose/kopano/konnect/Caddyfile.v2
+++ b/compose/kopano/konnect/Caddyfile.v2
@@ -1,76 +1,32 @@
-{$KOPANO_KONNECT_DOMAIN}:80 {
-	# errors stderr
-	log
-
-	# konnect oidc
-	reverse_proxy /.well-known/openid-configuration kopano_konnect:8777
-	reverse_proxy /konnect/v1/jwks.json kopano_konnect:8777
-	reverse_proxy /konnect/v1/token kopano_konnect:8777
-	reverse_proxy /konnect/v1/userinfo kopano_konnect:8777
-	reverse_proxy /konnect/v1/static kopano_konnect:8777
-	reverse_proxy /konnect/v1/session kopano_konnect:8777
-	reverse_proxy /konnect/v1/register kopano_konnect:8777
-
-	# konnect identifier login area
-	reverse_proxy /signin/ kopano_konnect:8777 {
-#		transparent
-	}
-
-	# owncloud 10
-	reverse_proxy /oc10 owncloud:8080 {
-#		without /oc10
-#		transparent
-	}
-}
-
-{$KOPANO_KONNECT_DOMAIN}:443 {
+{$KOPANO_KONNECT_DOMAIN} {
 	# errors stderr
 	log
 
 	# https://caddyserver.com/docs/caddyfile/directives/tls
 	# abiosoft/caddy:latest caddy_version 1.0.3 interprets 'tls internal' as an email-address and fails.
 	# caddy/latest CADDY_VERSION: 2.1.1 understands tls internal.
-	tls internal
+	#	tls internal
 
 	# konnect oidc
-	reverse_proxy /.well-known/openid-configuration kopano_konnect:8777
-	reverse_proxy /konnect/v1/jwks.json kopano_konnect:8777
-	reverse_proxy /konnect/v1/token kopano_konnect:8777
-	reverse_proxy /konnect/v1/userinfo kopano_konnect:8777
-	reverse_proxy /konnect/v1/static kopano_konnect:8777
-	reverse_proxy /konnect/v1/session kopano_konnect:8777
-	reverse_proxy /konnect/v1/register kopano_konnect:8777
-
+	everse_proxy /.well-known/* kopano_konnect:8777
+	reverse_proxy /konnect/* kopano_konnect:8777
+	
 	# konnect identifier login area
-	reverse_proxy /signin/ kopano_konnect:8777 {
-#		transparent
+	reverse_proxy /signin/* kopano_konnect:8777 {
 	}
 
-	# owncloud 10
+	# owncloud 10 FIXME: what is this???
 	reverse_proxy /oc10 owncloud:8080 {
-#		without /oc10
-#		transparent
 	}
 }
 
-{$OWNCLOUD_DOMAIN}:80 {
+{$OWNCLOUD_DOMAIN} {
 	# errors stderr
 	log
 
-	# owncloud 10
-	reverse_proxy / owncloud:8080 {
-#		transparent
-	}
-}
-
-{$OWNCLOUD_DOMAIN}:443 {
-	# errors stderr
-	log
-
-	tls internal
+	# tls internal
 
 	# owncloud 10
-	reverse_proxy / owncloud:8080 {
-#		transparent
+	reverse_proxy owncloud:8080 {
 	}
 }

--- a/compose/kopano/konnect/Caddyfile.v2
+++ b/compose/kopano/konnect/Caddyfile.v2
@@ -24,13 +24,19 @@
 	# errors stderr
 	log
 
+	## let caddy do selfsigned certs internally (oidc does not like them??):
 	# tls internal
+	## or better let it fetch a cert from letsencrypt (default!) ...
 
 	# owncloud 10
 	## simple static well known, directly to the idp:
 	# reverse_proxy /.well-known/* kopano_konnect:8777
+	## better let the well-known url be handled by the openidconnect app:
+	redir /.well-known/openid-configuration /index.php/apps/openidconnect/config 301
+	## best, do so with an internal redirect, so that it is invisible to the web clients.
+	rewrite /.well-known/openid-configuration /index.php/apps/openidconnect/config
+	## avoid a security warning:
+	header Strict-Transport-Security max-age=15552000;
 	reverse_proxy owncloud:8080 {
-	  ## more correct well-known, handled by the openidconnet app:
-	  redir /.well-known/openid-configuration /index.php/apps/openidconnect/config
 	}
 }

--- a/compose/kopano/konnect/Caddyfile.v2
+++ b/compose/kopano/konnect/Caddyfile.v2
@@ -27,7 +27,10 @@
 	# tls internal
 
 	# owncloud 10
-	reverse_proxy /.well-known/* kopano_konnect:8777
+	## simple static well known, directly to the idp:
+	# reverse_proxy /.well-known/* kopano_konnect:8777
 	reverse_proxy owncloud:8080 {
+	  ## more correct well-known, handled by the openidconnet app:
+	  redir /.well-known/openid-configuration /index.php/apps/openidconnect/config
 	}
 }

--- a/compose/kopano/konnect/Caddyfile.v2
+++ b/compose/kopano/konnect/Caddyfile.v2
@@ -27,6 +27,7 @@
 	# tls internal
 
 	# owncloud 10
+	reverse_proxy /.well-known/* kopano_konnect:8777
 	reverse_proxy owncloud:8080 {
 	}
 }

--- a/compose/kopano/konnect/README.md
+++ b/compose/kopano/konnect/README.md
@@ -34,16 +34,17 @@ docker-compose \
 Then manually sync LDAP users
 
 ```
-occ user:sync 'OCA\User_LDAP\User_Proxy'
+docker exec compose_owncloud_1 occ user:sync --missing-account-action=disable 'OCA\User_LDAP\User_Proxy'
+docker exec compose_owncloud_1 occ app:list openidconnect
 ```
 
-And enable te openidconnect app
+Confirm that the openidconnect app is enabled. If not, do
 
 ```
-occ a:e openidconnect
+occ app:enable openidconnect
 ```
 
-Go to owncloud: https://owncloud.docker-playground.local
+Go to owncloud: http://owncloud.docker-playground.local:9680
 Click the alternative login button 'Kopano'
 
 On the login of kopano konnect use aaliyah_abernathy / secret to login

--- a/compose/kopano/konnect/README.md
+++ b/compose/kopano/konnect/README.md
@@ -13,6 +13,9 @@ start an ownCloud instance with a Kopano IDP:
 export KOPANO_KONNECT_DOMAIN konnect.docker-playground.local
 export OWNCLOUD_DOMAIN owncloud.docker-playground.local
 
+docker system prune -f
+docker volume prune -f
+
 docker-compose \
     -f owncloud-base.yml \
     -f owncloud-official.yml \

--- a/compose/kopano/konnect/README.md
+++ b/compose/kopano/konnect/README.md
@@ -20,6 +20,7 @@ docker-compose \
     -f database/mariadb.yml \
     -f ldap/openldap.yml \
     -f ldap/openldap-mount-ldif.yml \
+    -f owncloud-exported-ports.yml \
     -f ldap/openldap-autoconfig-base.yml \
     -f kopano/konnect/docker-compose.yml \
     up

--- a/compose/kopano/konnect/README.md
+++ b/compose/kopano/konnect/README.md
@@ -34,7 +34,7 @@ docker-compose \
 Then manually sync LDAP users
 
 ```
-occ user:sync "OCA\User_LDAP\User_Proxy"
+occ user:sync 'OCA\User_LDAP\User_Proxy'
 ```
 
 And enable te openidconnect app

--- a/compose/kopano/konnect/README.md
+++ b/compose/kopano/konnect/README.md
@@ -1,7 +1,13 @@
-Setup the domain name in /etc/hosts - assuming you are on linux
+Setup the domain name in /etc/hosts - assuming you are on linux:
 
+```
 127.0.0.1 konnect.docker-playground.local
 127.0.0.1 owncloud.docker-playground.local
+```
+
+Then use the following command to
+start an ownCloud instance with a Kopano IDP:
+
 
 ```console
 KOPANO_KONNECT_DOMAIN=konnect.docker-playground.local
@@ -16,6 +22,18 @@ docker-compose \
     -f ldap/openldap-autoconfig-base.yml \
     -f kopano/konnect/docker-compose.yml \
     up
+```
+
+Then manually sync LDAP users
+
+```
+occ user:sync "OCA\User_LDAP\User_Proxy"
+```
+
+And enable te openidconnect app
+
+```
+occ a:e openidconnect
 ```
 
 Go to owncloud: https://owncloud.docker-playground.local

--- a/compose/kopano/konnect/README.md
+++ b/compose/kopano/konnect/README.md
@@ -46,9 +46,11 @@ occ app:enable openidconnect
 
 Go to owncloud: http://owncloud.docker-playground.local:9680
 Click the alternative login button 'Kopano'
-
 On the login of kopano konnect use aaliyah_abernathy / secret to login
 
-This is the well-known address to be used for OpenID Connect
+Local administrator user: admin / admin
+
+This is the well-known address to be used for OpenID Connect (must be available in the owncloud domain!):
 https://konnect.docker-playground.local/.well-known/openid-configuration
+https://owncloud.docker-playground.local/.well-known/openid-configuration
 

--- a/compose/kopano/konnect/README.md
+++ b/compose/kopano/konnect/README.md
@@ -10,8 +10,9 @@ start an ownCloud instance with a Kopano IDP:
 
 
 ```console
-KOPANO_KONNECT_DOMAIN=konnect.docker-playground.local
-OWNCLOUD_DOMAIN=owncloud.docker-playground.local
+export KOPANO_KONNECT_DOMAIN konnect.docker-playground.local
+export OWNCLOUD_DOMAIN owncloud.docker-playground.local
+
 docker-compose \
     -f owncloud-base.yml \
     -f owncloud-official.yml \

--- a/compose/kopano/konnect/README.md
+++ b/compose/kopano/konnect/README.md
@@ -14,7 +14,7 @@ export KOPANO_KONNECT_DOMAIN=konnect.docker-playground.local
 export OWNCLOUD_DOMAIN=owncloud.docker-playground.local
 echo >> /etc/hosts 127.0.0.1 $KOPANO_KONNECT_DOMAIN
 echo >> /etc/hosts 127.0.0.1 $OWNCLOUD_DOMAIN
-    
+
 docker system prune -f
 docker volume prune -f
 

--- a/compose/kopano/konnect/README.md
+++ b/compose/kopano/konnect/README.md
@@ -10,9 +10,11 @@ start an ownCloud instance with a Kopano IDP:
 
 
 ```console
-export KOPANO_KONNECT_DOMAIN konnect.docker-playground.local
-export OWNCLOUD_DOMAIN owncloud.docker-playground.local
-
+export KOPANO_KONNECT_DOMAIN=konnect.docker-playground.local
+export OWNCLOUD_DOMAIN=owncloud.docker-playground.local
+echo >> /etc/hosts 127.0.0.1 $KOPANO_KONNECT_DOMAIN
+echo >> /etc/hosts 127.0.0.1 $OWNCLOUD_DOMAIN
+    
 docker system prune -f
 docker volume prune -f
 

--- a/compose/kopano/konnect/docker-compose.yml
+++ b/compose/kopano/konnect/docker-compose.yml
@@ -54,10 +54,14 @@ services:
       - /tmp
 
   caddy:
+    ## abiosoft/caddy:latest: is caddy_version: 1.0.3 -- cannot do: 'tls internal' is an invalid email, and 'tls off' causes ssl3_get_record:wrong version number
     image: "abiosoft/caddy:latest"
+    ## caddy:latest: is CADDY_VERSION: v2.1.1 -- 
+    # image: "caddy:latest"
     volumes:
       - ./.caddy:/root/.caddy # to sync mkcert certificates to Caddy
-      - ./kopano/konnect/Caddyfile:/etc/Caddyfile  # to mount custom Caddyfile
+      - ./kopano/konnect/Caddyfile:/etc/Caddyfile  # caddy 1.0.3: to mount custom Caddyfile
+      # - ./kopano/konnect/Caddyfile.v2:/etc/caddy/Caddyfile  # caddy 2.1.1: to mount custom Caddyfile
     ports:
       - 80:80
       - 443:443
@@ -65,6 +69,7 @@ services:
     environment:
       - ACME_AGREE=true
       - KOPANO_KONNECT_DOMAIN=${KOPANO_KONNECT_DOMAIN}
+      - OWNCLOUD_DOMAIN=${OWNCLOUD_DOMAIN}
     networks: 
       default:
         aliases: 

--- a/compose/kopano/konnect/docker-compose.yml
+++ b/compose/kopano/konnect/docker-compose.yml
@@ -77,8 +77,9 @@ services:
     environment:
       - KOPANO_KONNECT_DOMAIN=${KOPANO_KONNECT_DOMAIN}
       - OWNCLOUD_DOMAIN=${OWNCLOUD_DOMAIN}
-      - OWNCLOUD_APPS_INSTALL=https://github.com/owncloud/openidconnect/releases/download/v0.2.0/openidconnect-0.2.0.tar.gz
-      - OWNCLOUD_APPS_ENABLE="openidconnect"
+      # - OWNCLOUD_APPS_INSTALL=https://github.com/owncloud/openidconnect/releases/download/v0.2.0/openidconnect-0.2.0.tar.gz
+      - OWNCLOUD_APPS_INSTALL=https://github.com/owncloud/openidconnect/releases/download/v1.0.0RC2/openidconnect-1.0.0RC2.tar.gz
+      - OWNCLOUD_APPS_ENABLE=openidconnect
       - OWNCLOUD_LOGLEVEL=0
       
 volumes:

--- a/compose/kopano/konnect/docker-compose.yml
+++ b/compose/kopano/konnect/docker-compose.yml
@@ -57,11 +57,11 @@ services:
     ## abiosoft/caddy:latest: is caddy_version: 1.0.3 -- cannot do: 'tls internal' is an invalid email, and 'tls off' causes ssl3_get_record:wrong version number
     image: "abiosoft/caddy:latest"
     ## caddy:latest: is CADDY_VERSION: v2.1.1 -- 
-    # image: "caddy:latest"
+    image: "caddy:2.1.1"
     volumes:
       - ./.caddy:/root/.caddy # to sync mkcert certificates to Caddy
-      - ./kopano/konnect/Caddyfile:/etc/Caddyfile  # caddy 1.0.3: to mount custom Caddyfile
-      # - ./kopano/konnect/Caddyfile.v2:/etc/caddy/Caddyfile  # caddy 2.1.1: to mount custom Caddyfile
+      # - ./kopano/konnect/Caddyfile:/etc/Caddyfile  # caddy 1.0.3: to mount custom Caddyfile
+      - ./kopano/konnect/Caddyfile.v2:/etc/caddy/Caddyfile  # caddy 2.1.1: to mount custom Caddyfile
     ports:
       - 80:80
       - 443:443

--- a/compose/kopano/konnect/konnectd-identifier-registration.yaml
+++ b/compose/kopano/konnect/konnectd-identifier-registration.yaml
@@ -8,23 +8,28 @@ clients:
 
   - id: xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69
     secret: UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh
+    name: ownCloud desktop client
     application_type: native
     insecure: true
+    trusted: true
 
   - id: e4rAsNUSIUs0lF4nbv9FmCeUkTlV9GdgTLDH1b5uie7syb90SzEVrbN7HIpmWJeD
     secret: dInFYGV33xKzhbRmpqQltYNdfLdJIfJ9L5ISoKhNoT9qZftpdWSP71VrpGR9pmoD
     application_type: native
+    name: ownCloud android app
     redirect_uris:
       - oc://android.owncloud.com
 
   - id: mxd5OQDk6es5LzOzRvidJNfXLUZS2oN3oUFeXPP8LpPrhx3UroJFduGEYIBOxkY1
     secret: KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx
+    name: ownCloud iOS app
     application_type: native
     redirect_uris:
       - oc://ios.owncloud.com
       - oc.ios://ios.owncloud.com
 
   - id: phoenix
+    name: ownCloud Web
     application_type: web
     trusted: true
     redirect_uris:

--- a/compose/kopano/konnect/openid.sh
+++ b/compose/kopano/konnect/openid.sh
@@ -12,8 +12,7 @@ CONFIG=$(cat <<EOF
             "autoRedirectOnLoginPage": false,
             "redirect-url": "https://$OWNCLOUD_DOMAIN/index.php/apps/openidconnect/redirect",
             "mode": "userid",
-            "search-attribute": "preferred_username",
-            "use-token-introspection-endpoint": false
+            "search-attribute": "preferred_username"
         },
         "debug": true
     }

--- a/compose/kopano/konnect/openid.sh
+++ b/compose/kopano/konnect/openid.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -x
 
+# line removed, to workaround https://github.com/owncloud/openidconnect/pull/98
+# "use-token-introspection-endpoint": false
+
 CONFIG=$(cat <<EOF
 {
     "system": {

--- a/compose/ldap/ldap.sh
+++ b/compose/ldap/ldap.sh
@@ -51,7 +51,7 @@ CONFIG=$(cat <<EOF
             "s01ldap_userfilter_groups": "",
             "s01ldap_userfilter_objectclass": "",
             "s01ldap_userlist_filter": "(objectclass=*)",
-            "s01use_memberof_to_detect_membership": "1",
+            "s01use_memberof_to_detect_membership": "1"
         }
     }
 }


### PR DESCRIPTION
Here is a PR for the fixes found by @pmaier1

He says:
I tried that docker-compose set up out of curiosity and have it running. maybe my findings on the way can help you:
1) Caddy didn't like this https://github.com/owncloud-docker/compose-playground/blob/master/compose/kopano/konnect/Caddyfile#L5 / https://github.com/owncloud-docker/compose-playground/blob/master/compose/kopano/konnect/Caddyfile#L32 => changing to
tls internal made it work for me (see https://caddyserver.com/docs/caddyfile/directives/tls)
2) The comma at the end of this line is wrong and makes the automated LDAP config fail https://github.com/owncloud-docker/compose-playground/blob/master/compose/ldap/ldap.sh#L54
3) You need to manually sync LDAP users => occ user:sync "OCA\User_LDAP\User_Proxy"
4) You need to manually enable the OIDC app => occ a:e openidconnect
5) For me it only works with https://github.com/owncloud/openidconnect/releases/download/v0.2.0/openidconnect-0.2.0.tar.gz => the RC builds seem wrong (I noticed they are half the size of 0.2.0)